### PR TITLE
fixing the find_signer method in Mobius\Blockchain\Account

### DIFF
--- a/src/blockchain/account.php
+++ b/src/blockchain/account.php
@@ -110,7 +110,7 @@ class Account{
         $signers = $this->info()->getSigners();
         if($signers){
             foreach($signers as $signer){
-                if($signer['public_key'] == $address){
+                if($signer['key'] == $address){
                     return $signer;
                 }
             }


### PR DESCRIPTION
the bug was: 

User / Dev account flagged as not Authorized (=> Exception raised)
although the signer was indeed added in the Stellar testnet ledger.

That simple fix worked for me!